### PR TITLE
Ensure `file` is relative to `GITHUB_WORKSPACE`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [pull_request, push]
 jobs:
   reviewdog:
     runs-on: ubuntu-latest

--- a/lib/rspec/github/formatter.rb
+++ b/lib/rspec/github/formatter.rb
@@ -8,13 +8,26 @@ module RSpec
     class Formatter < RSpec::Core::Formatters::BaseFormatter
       RSpec::Core::Formatters.register self, :example_failed, :example_pending
 
+      def self.relative_path(path)
+        if (workspace = ENV['GITHUB_WORKSPACE'])
+          workspace = "#{File.realpath(workspace)}#{File::SEPARATOR}"
+          absolute_path = File.realpath(path)
+
+          return absolute_path.delete_prefix(workspace) if absolute_path.start_with?(workspace)
+        end
+
+        path
+      end
+
       def example_failed(failure)
         file, line = failure.example.location.split(':')
+        file = self.class.relative_path(file)
         output.puts "\n::error file=#{file},line=#{line}::#{failure.message_lines.join('%0A')}"
       end
 
       def example_pending(pending)
         file, line = pending.example.location.split(':')
+        file = self.class.relative_path(file)
         output.puts "\n::warning file=#{file},line=#{line}::#{pending.example.full_description}"
       end
     end

--- a/lib/rspec/github/formatter.rb
+++ b/lib/rspec/github/formatter.rb
@@ -9,14 +9,8 @@ module RSpec
       RSpec::Core::Formatters.register self, :example_failed, :example_pending
 
       def self.relative_path(path)
-        if (workspace = ENV['GITHUB_WORKSPACE'])
-          workspace = "#{File.realpath(workspace)}#{File::SEPARATOR}"
-          absolute_path = File.realpath(path)
-
-          return absolute_path.delete_prefix(workspace) if absolute_path.start_with?(workspace)
-        end
-
-        path
+        workspace = File.realpath(ENV.fetch('GITHUB_WORKSPACE', '.'))
+        File.realpath(path).delete_prefix("#{workspace}#{File::SEPARATOR}")
       end
 
       def example_failed(failure)

--- a/spec/rspec/github/formatter_spec.rb
+++ b/spec/rspec/github/formatter_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 RSpec.describe RSpec::Github::Formatter do
   let(:output) { StringIO.new }
   let(:formatter) { described_class.new(output) }
@@ -20,6 +22,59 @@ RSpec.describe RSpec::Github::Formatter do
       description: 'is expected to validate presence of name',
       location: './spec/models/user_spec.rb:12'
     )
+  end
+
+  before do
+    allow(File).to receive(:realpath).and_call_original
+    allow(File).to receive(:realpath).with('./spec/models/user_spec.rb')
+                                     .and_return(File.join(Dir.pwd, 'spec/models/user_spec.rb'))
+  end
+
+  describe '::relative_path' do
+    around do |example|
+      saved_github_workspace = ENV['GITHUB_WORKSPACE']
+      ENV['GITHUB_WORKSPACE'] = github_workspace
+
+      FileUtils.mkpath File.dirname(absolute_path)
+      FileUtils.touch absolute_path
+
+      Dir.chdir tmpdir do
+        example.run
+      end
+    ensure
+      FileUtils.rm_r tmpdir
+      ENV['GITHUB_WORKSPACE'] = saved_github_workspace
+    end
+
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:relative_path) { 'this/is/a/relative_path.rb' }
+    let(:absolute_path) { File.join(tmpdir, relative_path) }
+
+    context 'if GITHUB_WORKSPACE is set' do
+      let(:github_workspace) { tmpdir }
+
+      it 'returns the path relative to it when already inside it' do
+        expect(described_class.relative_path('this/is/a/relative_path.rb')).to eq('this/is/a/relative_path.rb')
+      end
+
+      it 'returns the path relative to it when in a subdirectory of it' do
+        Dir.chdir 'this/is' do
+          expect(described_class.relative_path('a/relative_path.rb')).to eq('this/is/a/relative_path.rb')
+        end
+      end
+    end
+
+    context 'if GITHUB_WORKSPACE is unset' do
+      let(:github_workspace) { nil }
+
+      it 'returns the unchanged relative path' do
+        expect(described_class.relative_path('this/is/a/relative_path.rb')).to eq 'this/is/a/relative_path.rb'
+      end
+
+      it 'returns the relative path without a ./ prefix' do
+        expect(described_class.relative_path('./this/is/a/relative_path.rb')).to eq 'this/is/a/relative_path.rb'
+      end
+    end
   end
 
   describe '#example_failed' do
@@ -43,7 +98,7 @@ RSpec.describe RSpec::Github::Formatter do
     it 'outputs the GitHub annotation formatted error' do
       is_expected.to eq <<~MESSAGE
 
-        ::error file=./spec/models/user_spec.rb,line=12::#{notification.message_lines.join('%0A')}
+        ::error file=spec/models/user_spec.rb,line=12::#{notification.message_lines.join('%0A')}
       MESSAGE
     end
   end
@@ -61,7 +116,7 @@ RSpec.describe RSpec::Github::Formatter do
     it 'outputs the GitHub annotation formatted error' do
       is_expected.to eq <<~MESSAGE
 
-        ::warning file=./spec/models/user_spec.rb,line=12::#{example.full_description}
+        ::warning file=spec/models/user_spec.rb,line=12::#{example.full_description}
       MESSAGE
     end
   end


### PR DESCRIPTION
When running `rspec` in a subdirectory, no annotations are shown currently, since `file` has to be relative to the `GITHUB_WORKSPACE`.