### PR TITLE
Improve annotation messages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,8 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Run RSpec in GITHUB_WORKSPACE
-        run: '! bundle exec rspec spec/integration'
+        run: '! bundle exec rspec spec/integration/failing_spec.rb'
       - name: Run RSpec in sub-directory of GITHUB_WORKSPACE
         run: |
-          mkdir subdirectory
-          cd subdirectory
-          ln -s ../spec spec
-          ln -s ../.rspec .rspec
-          ! bundle exec rspec spec/integration
+          cd spec/integration
+          bundle exec rspec relative_path/pending_spec.rb --require ../spec_helper --format RSpec::Github::Formatter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run RSpec
         run: bundle exec rspec spec/rspec
   e2e:
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -56,5 +55,12 @@ jobs:
           gem install bundler:2.1.4 --no-doc
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-      - name: Run RSpec
+      - name: Run RSpec in GITHUB_WORKSPACE
         run: '! bundle exec rspec spec/integration'
+      - name: Run RSpec in sub-directory of GITHUB_WORKSPACE
+        run: |
+          mkdir subdirectory
+          cd subdirectory
+          ln -s ../spec spec
+          ln -s ../.rspec .rspec
+          ! bundle exec rspec spec/integration

--- a/lib/rspec/github/example_decorator.rb
+++ b/lib/rspec/github/example_decorator.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module RSpec
+  module Github
+    class ExampleDecorator < SimpleDelegator
+      # See https://github.community/t/set-output-truncates-multiline-strings/16852/3.
+      ESCAPE_MAP = {
+        '%' => '%25',
+        "\n" => '%0A',
+        "\r" => '%0D'
+      }.freeze
+
+      def line
+        example.location.split(':')[1]
+      end
+
+      def annotation
+        "#{example.full_description}\n\n#{message}"
+          .gsub(Regexp.union(ESCAPE_MAP.keys), ESCAPE_MAP)
+      end
+
+      def path
+        File.realpath(raw_path).delete_prefix("#{workspace}#{File::SEPARATOR}")
+      end
+
+      private
+
+      def message
+        if respond_to? :message_lines
+          message_lines.join("\n")
+        else
+          "#{example.skip ? 'Skipped' : 'Pending'}: #{example.execution_result.pending_message}"
+        end
+      end
+
+      def raw_path
+        example.location.split(':')[0]
+      end
+
+      def workspace
+        File.realpath(ENV.fetch('GITHUB_WORKSPACE', '.'))
+      end
+    end
+  end
+end

--- a/lib/rspec/github/formatter.rb
+++ b/lib/rspec/github/formatter.rb
@@ -2,7 +2,7 @@
 
 require 'rspec/core'
 require 'rspec/core/formatters/base_formatter'
-require 'rspec/github/example_decorator'
+require 'rspec/github/notification_decorator'
 
 module RSpec
   module Github
@@ -10,15 +10,15 @@ module RSpec
       RSpec::Core::Formatters.register self, :example_failed, :example_pending
 
       def example_failed(failure)
-        example = ExampleDecorator.new(failure)
+        notification = NotificationDecorator.new(failure)
 
-        output.puts "\n::error file=#{example.path},line=#{example.line}::#{example.annotation}"
+        output.puts "\n::error file=#{notification.path},line=#{notification.line}::#{notification.annotation}"
       end
 
       def example_pending(pending)
-        example = ExampleDecorator.new(pending)
+        notification = NotificationDecorator.new(pending)
 
-        output.puts "\n::warning file=#{example.path},line=#{example.line}::#{example.annotation}"
+        output.puts "\n::warning file=#{notification.path},line=#{notification.line}::#{notification.annotation}"
       end
     end
   end

--- a/lib/rspec/github/formatter.rb
+++ b/lib/rspec/github/formatter.rb
@@ -2,55 +2,23 @@
 
 require 'rspec/core'
 require 'rspec/core/formatters/base_formatter'
+require 'rspec/github/example_decorator'
 
 module RSpec
   module Github
     class Formatter < RSpec::Core::Formatters::BaseFormatter
       RSpec::Core::Formatters.register self, :example_failed, :example_pending
 
-      def self.escape(string)
-        # See https://github.community/t/set-output-truncates-multiline-strings/16852/3.
-        string.gsub('%', '%25')
-              .gsub("\n", '%0A')
-              .gsub("\r", '%0D')
-      end
-
-      def self.annotation(type, file, line, message)
-        file = escape(file)
-        message = escape(message)
-
-        "::#{type} file=#{file},line=#{line}::#{message}"
-      end
-
-      def self.relative_path(path)
-        workspace = File.realpath(ENV.fetch('GITHUB_WORKSPACE', '.'))
-        File.realpath(path).delete_prefix("#{workspace}#{File::SEPARATOR}")
-      end
-
       def example_failed(failure)
-        file, line = failure.example.location.split(':')
-        file = self.class.relative_path(file)
+        example = ExampleDecorator.new(failure)
 
-        description = failure.example.full_description
-        message = failure.message_lines.join("\n")
-        annotation = "#{description}\n\n#{message}"
-
-        output.puts "\n#{self.class.annotation(:error, file, line, annotation)}"
+        output.puts "\n::error file=#{example.path},line=#{example.line}::#{example.annotation}"
       end
 
       def example_pending(pending)
-        file, line = pending.example.location.split(':')
-        file = self.class.relative_path(file)
+        example = ExampleDecorator.new(pending)
 
-        description = pending.example.full_description
-        message = if pending.example.skip
-                    "Skipped: #{pending.example.execution_result.pending_message}"
-                  else
-                    "Pending: #{pending.example.execution_result.pending_message}"
-                  end
-        annotation = "#{description}\n\n#{message}"
-
-        output.puts "\n#{self.class.annotation(:warning, file, line, annotation)}"
+        output.puts "\n::warning file=#{example.path},line=#{example.line}::#{example.annotation}"
       end
     end
   end

--- a/lib/rspec/github/formatter.rb
+++ b/lib/rspec/github/formatter.rb
@@ -8,6 +8,20 @@ module RSpec
     class Formatter < RSpec::Core::Formatters::BaseFormatter
       RSpec::Core::Formatters.register self, :example_failed, :example_pending
 
+      def self.escape(string)
+        # See https://github.community/t/set-output-truncates-multiline-strings/16852/3.
+        string.gsub('%', '%25')
+              .gsub("\n", '%0A')
+              .gsub("\r", '%0D')
+      end
+
+      def self.annotation(type, file, line, message)
+        file = escape(file)
+        message = escape(message)
+
+        "::#{type} file=#{file},line=#{line}::#{message}"
+      end
+
       def self.relative_path(path)
         workspace = File.realpath(ENV.fetch('GITHUB_WORKSPACE', '.'))
         File.realpath(path).delete_prefix("#{workspace}#{File::SEPARATOR}")
@@ -16,13 +30,27 @@ module RSpec
       def example_failed(failure)
         file, line = failure.example.location.split(':')
         file = self.class.relative_path(file)
-        output.puts "\n::error file=#{file},line=#{line}::#{failure.message_lines.join('%0A')}"
+
+        description = failure.example.full_description
+        message = failure.message_lines.join("\n")
+        annotation = "#{description}\n\n#{message}"
+
+        output.puts "\n#{self.class.annotation(:error, file, line, annotation)}"
       end
 
       def example_pending(pending)
         file, line = pending.example.location.split(':')
         file = self.class.relative_path(file)
-        output.puts "\n::warning file=#{file},line=#{line}::#{pending.example.full_description}"
+
+        description = pending.example.full_description
+        message = if pending.example.skip
+                    "Skipped: #{pending.example.execution_result.pending_message}"
+                  else
+                    "Pending: #{pending.example.execution_result.pending_message}"
+                  end
+        annotation = "#{description}\n\n#{message}"
+
+        output.puts "\n#{self.class.annotation(:warning, file, line, annotation)}"
       end
     end
   end

--- a/lib/rspec/github/notification_decorator.rb
+++ b/lib/rspec/github/notification_decorator.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-require 'delegate'
-
 module RSpec
   module Github
-    class ExampleDecorator < SimpleDelegator
+    class NotificationDecorator
       # See https://github.community/t/set-output-truncates-multiline-strings/16852/3.
       ESCAPE_MAP = {
         '%' => '%25',
         "\n" => '%0A',
         "\r" => '%0D'
       }.freeze
+
+      def initialize(notification)
+        @notification = notification
+      end
 
       def line
         example.location.split(':')[1]
@@ -27,9 +29,13 @@ module RSpec
 
       private
 
+      def example
+        @notification.example
+      end
+
       def message
-        if respond_to? :message_lines
-          message_lines.join("\n")
+        if @notification.respond_to?(:message_lines)
+          @notification.message_lines.join("\n")
         else
           "#{example.skip ? 'Skipped' : 'Pending'}: #{example.execution_result.pending_message}"
         end

--- a/spec/integration/failing_spec.rb
+++ b/spec/integration/failing_spec.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
-RSpec.describe RSpec::Github do
+RSpec.describe RSpec::Github::Formatter do
   it 'creates an error annotation for failing specs' do
     expect(true).to eq false
   end
 
-  it 'creates a warning annotation for pending specs'
+  it 'creates a warning annotation for unimplemented specs'
+
+  it 'creates a warning annotation for pending specs' do
+    pending 'because it is failing'
+    raise
+  end
+
+  it 'creates a warning annotation for skipped specs' do
+    skip 'because reasons'
+  end
 
   it 'does not create an annotiation for passing specs' do
     expect(true).to eq true

--- a/spec/integration/relative_path/pending_spec.rb
+++ b/spec/integration/relative_path/pending_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe RSpec::Github::Formatter do
+  it 'adds annotiations correctly when running in a subdirectory'
+end


### PR DESCRIPTION
Always include the `full_description` as a title and show the reason for pending/skipped specs.

Also added another step to the `e2e` job running in a subdirectory.