### PR TITLE
Output rspec seed if used

### DIFF
--- a/lib/rspec/github/formatter.rb
+++ b/lib/rspec/github/formatter.rb
@@ -7,7 +7,7 @@ require 'rspec/github/notification_decorator'
 module RSpec
   module Github
     class Formatter < RSpec::Core::Formatters::BaseFormatter
-      RSpec::Core::Formatters.register self, :example_failed, :example_pending
+      RSpec::Core::Formatters.register self, :example_failed, :example_pending, :seed
 
       def example_failed(failure)
         notification = NotificationDecorator.new(failure)
@@ -19,6 +19,12 @@ module RSpec
         notification = NotificationDecorator.new(pending)
 
         output.puts "\n::warning file=#{notification.path},line=#{notification.line}::#{notification.annotation}"
+      end
+
+      def seed(notification)
+        return unless notification.seed_used?
+
+        output.puts notification.fully_formatted
       end
     end
   end

--- a/spec/rspec/github/formatter_spec.rb
+++ b/spec/rspec/github/formatter_spec.rb
@@ -137,4 +137,26 @@ RSpec.describe RSpec::Github::Formatter do
       end
     end
   end
+
+  describe '#seed' do
+    before { formatter.seed(notification) }
+
+    context 'when seed used' do
+      let(:notification) do
+        RSpec::Core::Notifications::SeedNotification.new(4242, true)
+      end
+
+      it 'outputs the fully formatted seed notification' do
+        is_expected.to eq "\nRandomized with seed 4242\n"
+      end
+    end
+
+    context 'when seed not used' do
+      let(:notification) do
+        RSpec::Core::Notifications::SeedNotification.new(nil, false)
+      end
+
+      it { is_expected.to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
Rspec supports running the specs in a [random order][1]. This helps in
surfacing any accidental dependencies and side effects in the test
suite. When debugging test failures caused by such side effects, it's
often necessary to reproduce the issue by running the specs in the same
order again. For that the seed value needs to be known and logged by the
formatter.

[1]: https://relishapp.com/rspec/rspec-core/v/3-8/docs/configuration/set-the-order-and-or-seed