### PR TITLE
chore: Add Dependabot for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [pull_request, push]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 jobs:
   reviewdog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Noticed a few of the Action dependencies were a version behind, so instead of a PR for that, the Dependabot could keep them in sync.
Filtered the pushes to the branches it creates so it doesn't double build them.