### PR TITLE
Update to current supported Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,28 @@
 name: CI
 on: [pull_request, push]
 jobs:
-  reviewdog:
+  rubocop:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.2
           bundler-cache: true
-      - name: rubocop
-        uses: reviewdog/action-rubocop@v1
-        with:
-          rubocop_version: gemfile
-          github_token: ${{ secrets.github_token }}
-          reporter: github-check
+      - name: Set-up RuboCop Problem Matcher
+        uses: r7kamura/rubocop-problem-matchers-action@v1
+      - name: Run rubocop
+        run: bundle exec rubocop
   rspec:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
-          - 2.4
-          - 2.5
-          - 2.6
           - 2.7
           - 3.0
+          - 3.1
+          - 3.2
     name: RSpec tests ruby ${{ matrix.ruby }}
     steps:
       - name: Check out code
@@ -43,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.2
           bundler-cache: true
       - name: Run RSpec in GITHUB_WORKSPACE
         run: '! bundle exec rspec spec/integration/failing_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   NewCops: enable
 
 # A top class comment is not needed for this simple gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,12 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.4.4)
-    parallel (1.20.1)
-    parser (3.0.1.1)
+    json (2.6.3)
+    parallel (1.22.1)
+    parser (3.2.1.1)
       ast (~> 2.4.1)
-    rainbow (3.0.0)
-    regexp_parser (2.1.1)
+    rainbow (3.1.1)
+    regexp_parser (2.7.0)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -28,19 +29,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.12.1)
+    rubocop (1.48.0)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.0.0.0)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.0.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.27.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
@@ -48,7 +50,7 @@ PLATFORMS
 DEPENDENCIES
   rspec (~> 3.0)
   rspec-github!
-  rubocop (~> 1.12.0)
+  rubocop (~> 1.12)
 
 BUNDLED WITH
    2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,6 @@ DEPENDENCIES
   rspec (~> 3.0)
   rspec-github!
   rubocop (~> 1.12.0)
-  rubocop-ast (~> 1.4.0)
 
 BUNDLED WITH
-   2.2.19
+   2.2.33

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rspec-core', '~> 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 1.12.0'
+  spec.add_development_dependency 'rubocop', '~> 1.12'
 end

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rspec-core', '~> 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.12'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rspec-core', '~> 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.12.0'
-  spec.add_development_dependency 'rubocop-ast', '~> 1.4.0'
 end

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Formatter for RSpec to show errors in GitHub action annotations'
   spec.homepage      = 'https://drieam.github.io/rspec-github'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage

--- a/spec/rspec/github/formatter_spec.rb
+++ b/spec/rspec/github/formatter_spec.rb
@@ -63,15 +63,15 @@ RSpec.describe RSpec::Github::Formatter do
 
     context 'relative_path to GITHUB_WORKSPACE' do
       around do |example|
-          saved_github_workspace = ENV['GITHUB_WORKSPACE']
-          ENV['GITHUB_WORKSPACE'] = tmpdir
+        saved_github_workspace = ENV.fetch('GITHUB_WORKSPACE', nil)
+        ENV['GITHUB_WORKSPACE'] = tmpdir
 
-          FileUtils.mkpath File.dirname(absolute_path)
-          FileUtils.touch absolute_path
+        FileUtils.mkpath File.dirname(absolute_path)
+        FileUtils.touch absolute_path
 
-          Dir.chdir tmpdir do
-            example.run
-          end
+        Dir.chdir tmpdir do
+          example.run
+        end
       ensure
         FileUtils.rm_r tmpdir
         ENV['GITHUB_WORKSPACE'] = saved_github_workspace

--- a/spec/rspec/github/formatter_spec.rb
+++ b/spec/rspec/github/formatter_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe RSpec::Github::Formatter do
 
     context 'relative_path to GITHUB_WORKSPACE' do
       around do |example|
-        begin
           saved_github_workspace = ENV['GITHUB_WORKSPACE']
           ENV['GITHUB_WORKSPACE'] = tmpdir
 
@@ -73,10 +72,9 @@ RSpec.describe RSpec::Github::Formatter do
           Dir.chdir tmpdir do
             example.run
           end
-        ensure
-          FileUtils.rm_r tmpdir
-          ENV['GITHUB_WORKSPACE'] = saved_github_workspace
-        end
+      ensure
+        FileUtils.rm_r tmpdir
+        ENV['GITHUB_WORKSPACE'] = saved_github_workspace
       end
 
       let(:tmpdir) { Dir.mktmpdir }


### PR DESCRIPTION
Update the CI matrix and Rubocop settings to match the currently supported Ruby versions. 2.7 will also hit EOL soon, but left it in.

I noticed that the reivewdog was pulling in a newer version than the Gemfile.lock and was failing PRs and pages build, so swaped to a plain version that uses the bundled gem version