### PR TITLE
ci: Replace reviewdog with plain Rubocop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - 'dependabot/**'
   pull_request:
 jobs:
-  reviewdog:
+  rubocop:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -14,12 +14,10 @@ jobs:
         with:
           ruby-version: '3.0'
           bundler-cache: true
-      - name: rubocop
-        uses: reviewdog/action-rubocop@v2
-        with:
-          rubocop_version: gemfile
-          github_token: ${{ secrets.github_token }}
-          reporter: github-check
+      - name: Set-up RuboCop Problem Matcher
+        uses: r7kamura/rubocop-problem-matchers-action@v1
+      - name: Run rubocop
+        run: bundle exec rubocop
   rspec:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Swap reviewdog with a plain Rubocop call, along with a problemmatcher to show issues on the PR files tab