### PR TITLE
chore: Update to current supported Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.0'
           bundler-cache: true
       - name: rubocop
         uses: reviewdog/action-rubocop@v2
@@ -25,11 +25,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.4
-          - 2.5
-          - 2.6
-          - 2.7
-          - 3.0
+          - '3.0'
+          - '3.1'
+          - '3.2'
     name: RSpec tests ruby ${{ matrix.ruby }}
     steps:
       - name: Check out code
@@ -47,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Run RSpec in GITHUB_WORKSPACE
         run: '! bundle exec rspec spec/integration/failing_spec.rb'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.0'
       - name: Replace version by tag value
         run: sed -i "s/'[0-9]\.[0-9]\..*'/'${GITHUB_REF##*/}'/" lib/rspec/github/version.rb
       - name: Publish to RubyGems

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 3.0
   NewCops: enable
 
 # A top class comment is not needed for this simple gem
@@ -14,3 +14,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb' # Specs just have large blocks
     - '*.gemspec'    # Is just one block
+
+# We don't support MFA publishing
+Gemspec/RequireMFA:
+  Enabled: false

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Formatter for RSpec to show errors in GitHub action annotations'
   spec.homepage      = 'https://drieam.github.io/rspec-github'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage

--- a/spec/rspec/github/formatter_spec.rb
+++ b/spec/rspec/github/formatter_spec.rb
@@ -63,20 +63,18 @@ RSpec.describe RSpec::Github::Formatter do
 
     context 'relative_path to GITHUB_WORKSPACE' do
       around do |example|
-        begin
-          saved_github_workspace = ENV['GITHUB_WORKSPACE']
-          ENV['GITHUB_WORKSPACE'] = tmpdir
+        saved_github_workspace = ENV.fetch('GITHUB_WORKSPACE', nil)
+        ENV['GITHUB_WORKSPACE'] = tmpdir
 
-          FileUtils.mkpath File.dirname(absolute_path)
-          FileUtils.touch absolute_path
+        FileUtils.mkpath File.dirname(absolute_path)
+        FileUtils.touch absolute_path
 
-          Dir.chdir tmpdir do
-            example.run
-          end
-        ensure
-          FileUtils.rm_r tmpdir
-          ENV['GITHUB_WORKSPACE'] = saved_github_workspace
+        Dir.chdir tmpdir do
+          example.run
         end
+      ensure
+        FileUtils.rm_r tmpdir
+        ENV['GITHUB_WORKSPACE'] = saved_github_workspace
       end
 
       let(:tmpdir) { Dir.mktmpdir }


### PR DESCRIPTION
Updated the supported ruby versions based on https://www.ruby-lang.org/en/downloads/branches/.