### PR TITLE
chore: remove hard rubocop-ast devDep

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,6 @@ DEPENDENCIES
   rspec (~> 3.0)
   rspec-github!
   rubocop (~> 1.12.0)
-  rubocop-ast (~> 1.4.0)
 
 BUNDLED WITH
    2.2.19

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rspec-core', '~> 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.12.0'
-  spec.add_development_dependency 'rubocop-ast', '~> 1.4.0'
 end


### PR DESCRIPTION
Maybe used to workaround somethig before, but it's already a dependency of rubocop