### PR TITLE
Annotate exception location instead of spec

### DIFF
--- a/lib/rspec/github/notification_decorator.rb
+++ b/lib/rspec/github/notification_decorator.rb
@@ -15,7 +15,7 @@ module RSpec
       end
 
       def line
-        example.location.split(':')[1]
+        location[1]
       end
 
       def annotation
@@ -25,7 +25,7 @@ module RSpec
 
       def path
         # TODO: use `delete_prefix` when dropping ruby 2.4 support
-        File.realpath(raw_path).sub(/\A#{workspace}#{File::SEPARATOR}/, '')
+        File.realpath(location[0]).sub(/\A#{workspace}#{File::SEPARATOR}/, '')
       end
 
       private
@@ -42,8 +42,12 @@ module RSpec
         end
       end
 
-      def raw_path
-        example.location.split(':')[0]
+      def location
+        if @notification.respond_to?(:exception)
+          @notification.exception.backtrace.first.split(':')
+        else
+          example.location.split(':')
+        end
       end
 
       def workspace

--- a/spec/integration/crashing_spec.rb
+++ b/spec/integration/crashing_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative './test_class.rb'
+
+RSpec.describe RSpec::Github::Formatter do
+  it 'creates an error annotation for crashing specs' do
+    expect(TestClass.crash).to eq true
+  end
+end

--- a/spec/integration/test_class.rb
+++ b/spec/integration/test_class.rb
@@ -1,0 +1,5 @@
+class TestClass
+    def self.crash
+        raise 'Ay!'
+    end
+end


### PR DESCRIPTION
This is just a test commit as the final version should be configurable. Instead, this can be used for early testing.

Closes #75