### PR TITLE
Bump Bundler version from 2.2.19 to 2.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,4 +59,4 @@ DEPENDENCIES
   rubocop (~> 1.65.1)
 
 BUNDLED WITH
-   2.2.19
+   2.6.0


### PR DESCRIPTION
The following error occurred when running `bundle install` with ruby 3.4.0rc1:

```
❯ bundle install
/ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/error.rb:105:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)

    DidYouMean::SPELL_CHECKERS.merge!(
              ^^^^^^^^^^^^^^^^
Did you mean?  DidYouMean::SpellChecker
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/error.rb:1:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/base.rb:3:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/base.rb:3:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor.rb:1:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor.rb:1:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendored_thor.rb:8:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/vendored_thor.rb:8:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/friendly_errors.rb:3:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/lib/bundler/friendly_errors.rb:3:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/exe/bundle:32:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/bundler-2.2.19/exe/bundle:32:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.0-rc1/bin/bundle:25:in 'Kernel#load'
        from /ydah/.rbenv/versions/3.4.0-rc1/bin/bundle:25:in '<main>'
```

related:
- https://github.com/rubygems/rubygems/issues/5234