### PR TITLE
Add Ruby 3.3 and ruby-head to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+          - ruby-head
     name: RSpec tests ruby ${{ matrix.ruby }}
     steps:
       - name: Check out code


### PR DESCRIPTION
This PR add Ruby 3.3 and ruby-head to CI workflow matrix.