### PR TITLE
ci: Run rubocop without reviewdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - 'dependabot/**'
   pull_request:
 jobs:
-  reviewdog:
+  rubocop:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -15,11 +15,7 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - name: rubocop
-        uses: reviewdog/action-rubocop@v2
-        with:
-          rubocop_version: gemfile
-          github_token: ${{ secrets.github_token }}
-          reporter: github-check
+        run: bundle exec rubocop
   rspec:
     runs-on: ubuntu-latest
     strategy:

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['{lib}/**/*']
 
-  spec.add_runtime_dependency 'rspec-core', '~> 3.0'
+  spec.add_dependency 'rspec-core', '~> 3.0'
 end


### PR DESCRIPTION
The `reviewdog` action needs to be removed as a required action and the `rubocop` action should be added as a required action.