### PR TITLE
Add support RSpec 4.0.0.beta1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,16 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
-    name: RSpec tests ruby ${{ matrix.ruby }}
+          - '4.0'
+        gemfile:
+          - rspec3
+          - rspec4
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+    name: RSpec tests ruby ${{ matrix.ruby }} with ${{ matrix.gemfile }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
---color
 --require spec_helper
 --format documentation
 --format RSpec::Github::Formatter

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   NewCops: enable
 
 # A top class comment is not needed for this simple gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,49 +2,65 @@ PATH
   remote: .
   specs:
     rspec-github (1.0.0.develop)
-      rspec-core (~> 3.0)
+      rspec-core (>= 3.0, < 5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
-    diff-lcs (1.5.1)
-    json (2.7.5)
-    language_server-protocol (3.17.0.3)
-    parallel (1.26.3)
-    parser (3.3.5.1)
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
+    bigdecimal (4.0.1)
+    diff-lcs (1.6.2)
+    json (2.19.1)
+    json-schema (6.2.0)
+      addressable (~> 2.8)
+      bigdecimal (>= 3.1, < 5)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    mcp (0.8.0)
+      json-schema (>= 4.1)
+    parallel (1.27.0)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
+    prism (1.9.0)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
-    regexp_parser (2.9.2)
-    rspec (3.13.0)
+    regexp_parser (2.11.3)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
-    rubocop (1.68.0)
+    rspec-support (3.13.7)
+    rubocop (1.85.1)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      mcp (~> 0.6)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 2.4, < 3.0)
-      rubocop-ast (>= 1.32.2, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.33.1)
-      parser (>= 3.3.1.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
     ruby-progressbar (1.13.0)
-    unicode-display_width (2.6.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   ruby
@@ -52,7 +68,36 @@ PLATFORMS
 DEPENDENCIES
   rspec (~> 3.13)
   rspec-github!
-  rubocop (~> 1.68.0)
+  rubocop (~> 1.85.0)
+
+CHECKSUMS
+  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  json (2.19.1) sha256=dd94fdc59e48bff85913829a32350b3148156bc4fd2a95a2568a78b11344082d
+  json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-github (1.0.0.develop)
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.85.1) sha256=3dbcf9e961baa4c376eeeb2a03913dca5e3987033b04d38fa538aa1e7406cc77
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
 
 BUNDLED WITH
-   2.6.0
+  4.0.8

--- a/gemfiles/rspec3.gemfile
+++ b/gemfiles/rspec3.gemfile
@@ -3,9 +3,8 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rspec-github.gemspec
-gemspec
+gemspec path: '../'
 
 group :development do
-  gem 'rspec', '~> 3.13'
-  gem 'rubocop', '~> 1.85.0'
+  gem 'rspec', '~> 3.0'
 end

--- a/gemfiles/rspec3.gemfile.lock
+++ b/gemfiles/rspec3.gemfile.lock
@@ -1,0 +1,42 @@
+PATH
+  remote: ..
+  specs:
+    rspec-github (1.0.0.develop)
+      rspec-core (>= 3.0, < 5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.6.2)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec (~> 3.0)
+  rspec-github!
+
+CHECKSUMS
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-github (1.0.0.develop)
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+
+BUNDLED WITH
+  4.0.8

--- a/gemfiles/rspec4.gemfile
+++ b/gemfiles/rspec4.gemfile
@@ -3,9 +3,8 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rspec-github.gemspec
-gemspec
+gemspec path: '../'
 
 group :development do
-  gem 'rspec', '~> 3.13'
-  gem 'rubocop', '~> 1.85.0'
+  gem 'rspec', '~> 4.0.0.beta1'
 end

--- a/gemfiles/rspec4.gemfile.lock
+++ b/gemfiles/rspec4.gemfile.lock
@@ -1,0 +1,42 @@
+PATH
+  remote: ..
+  specs:
+    rspec-github (1.0.0.develop)
+      rspec-core (>= 3.0, < 5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (2.0.0)
+    rspec (4.0.0.beta1)
+      rspec-core (= 4.0.0.beta1)
+      rspec-expectations (= 4.0.0.beta1)
+      rspec-mocks (= 4.0.0.beta1)
+    rspec-core (4.0.0.beta1)
+      rspec-support (= 4.0.0.beta1)
+    rspec-expectations (4.0.0.beta1)
+      diff-lcs (>= 1.6.0, < 3.0)
+      rspec-support (= 4.0.0.beta1)
+    rspec-mocks (4.0.0.beta1)
+      diff-lcs (>= 1.6.0, < 3.0)
+      rspec-support (= 4.0.0.beta1)
+    rspec-support (4.0.0.beta1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec (~> 4.0.0.beta1)
+  rspec-github!
+
+CHECKSUMS
+  diff-lcs (2.0.0) sha256=708a5d52ec2945b50f8f53a181174aa1ef2c496edf81c05957fe956dabb363d5
+  rspec (4.0.0.beta1) sha256=7edd7fb4e25fe5544146268196bc43b610851ea61581f38fe6ac1f03f4ca6114
+  rspec-core (4.0.0.beta1) sha256=11ad8b2f752d08aa5ecc699bd534f2253fe0939144af94365791f99bbefb575e
+  rspec-expectations (4.0.0.beta1) sha256=39b3d6b32876796a669ba3128b57a1dc0157056662e5a1ba6447b64831628904
+  rspec-github (1.0.0.develop)
+  rspec-mocks (4.0.0.beta1) sha256=6d88d9d89ebc16865ca748a1319740e3f8f5c3ca5c801c0c4cb2b8b76b91c95e
+  rspec-support (4.0.0.beta1) sha256=8f1231c022af7ccabe527ae05c53a8fab7e59fac5d0cc0e07452c8a395c06a44
+
+BUNDLED WITH
+  4.0.8

--- a/rspec-github.gemspec
+++ b/rspec-github.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Formatter for RSpec to show errors in GitHub action annotations'
   spec.homepage      = 'https://drieam.github.io/rspec-github'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.1')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.2.0')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['{lib}/**/*']
 
-  spec.add_dependency 'rspec-core', '~> 3.0'
+  spec.add_dependency 'rspec-core', '>= 3.0', '< 5'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,15 +2,19 @@
 
 require 'bundler/setup'
 require 'rspec/github'
+require 'rspec/core/version'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
-  config.disable_monkey_patching!
+  # Only perform this setup when running RSpec 3
+  if Gem::Requirement.new('~> 3.0').satisfied_by?(Gem::Version.new(RSpec::Core::Version::STRING))
+    # Disable RSpec exposing methods globally on `Module` and `main`
+    config.disable_monkey_patching!
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+    config.expect_with :rspec do |c|
+      c.syntax = :expect
+    end
   end
 end


### PR DESCRIPTION
Also added both RSpec 3 and 4 in the test matrix. At the same time dropped support for ruby 3.1 as it is a pain to keep the CI working with all the versions. Bundler has also been updated to version 4.

Closes #114
